### PR TITLE
remove locking to specific version in deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@
     ] }
     structopt = "0.3"
     tokio = { version = "1.4", features = [ "full" ] }
-    wasmtime = "1.0.0"
-    wasmtime-wasi = "1.0.0"
-    wasi-common = "1.0.0"
-    wasi-cap-std-sync = "1.0.0"
+    wasmtime = "*"
+    wasmtime-wasi = "*"
+    wasi-common = "*"
+    wasi-cap-std-sync = "*"
     wasi-experimental-http = { path = "crates/wasi-experimental-http" }
     wasi-experimental-http-wasmtime = { path = "crates/wasi-experimental-http-wasmtime" }
 

--- a/crates/wasi-experimental-http-wasmtime/Cargo.toml
+++ b/crates/wasi-experimental-http-wasmtime/Cargo.toml
@@ -18,9 +18,9 @@
         "blocking",
     ] }
     thiserror = "1.0"
-    tokio = { version = "1.4.0", features = [ "full" ] }
+    tokio = { version = "1", features = [ "full" ] }
     tracing = { version = "0.1", features = [ "log" ] }
-    url = "2.2.1"
-    wasmtime = "1.0.0"
-    wasmtime-wasi = "1.0.0"
-    wasi-common = "1.0.0"
+    url = "2"
+    wasmtime = "*"
+    wasmtime-wasi = "*"
+    wasi-common = "*"


### PR DESCRIPTION
this should allow to consume whichever version of wasmtime we define in lapce repo 