### PR TITLE
wasmtime: make add_to_linker<T: 'static>

### DIFF
--- a/crates/wasi-experimental-http-wasmtime/src/lib.rs
+++ b/crates/wasi-experimental-http-wasmtime/src/lib.rs
@@ -344,7 +344,7 @@ impl HttpState {
         Ok(HttpState { state })
     }
 
-    pub fn add_to_linker<T>(
+    pub fn add_to_linker<T: 'static>(
         &self,
         linker: &mut Linker<T>,
         get_cx: impl Fn(&T) -> HttpCtx + Send + Sync + 'static,


### PR DESCRIPTION
```
error[E0310]: the parameter type `T` may not live long enough
   --> /home/user/.cargo/git/checkouts/wasi-experimental-http-190d8a6effc3f6cb/80bea1240495/crates/wasi-experimental-http-wasmtime/src/lib.rs:465:9
    |
465 | /         linker.func_wrap(
466 | |             Self::MODULE,
467 | |             "req",
468 | |             move |mut caller: Caller<'_, T>,
...   |
508 | |             },
509 | |         )?;
    | |         ^
    | |         |
    | |_________the parameter type `T` must be valid for the static lifetime...
    |           ...so that the type `T` will meet its required lifetime bounds
    |
help: consider adding an explicit lifetime bound
    |
347 |     pub fn add_to_linker<T: 'static>(
    |                           +++++++++

For more information about this error, try `rustc --explain E0310`.
```